### PR TITLE
Make senders pluggable

### DIFF
--- a/config.ini
+++ b/config.ini
@@ -37,10 +37,9 @@ request_processor_num_threads = 10
 # queue limit for sender processor. See Monitoring API for reference
 sender_queue_limit = 50000
 
-# interval for batching apn messages
-apn_sender_interval_sec = 3
-apn_num_processes = 50
-gcm_num_processes = 50
+enabled_senders =
+  pushkin.sender.senders.ApnNotificationSender {"workers": 50}
+  pushkin.sender.senders.GcmNotificationSender {"workers": 50}
 
 [Log]
 # log configuration

--- a/pushkin/config.py
+++ b/pushkin/config.py
@@ -49,9 +49,7 @@ def init(configuration_file):
     global request_queue_limit
     global sender_batch_size
     global sender_queue_limit
-    global apn_sender_interval_sec
-    global gcm_num_processes
-    global apn_num_processes
+    global enabled_senders
     global dry_run
     global request_processor_num_threads
     global login_event_id
@@ -98,9 +96,7 @@ def init(configuration_file):
     request_queue_limit = config.getint(REQUEST_PROCESSOR_CONFIG_SECTION, 'queue_limit')
     sender_batch_size = config.getint(MESSENGER_CONFIG_SECTION, 'apns_batch_size')
     sender_queue_limit = config.getint(SENDER_CONFIG_SECTION, 'sender_queue_limit')
-    apn_sender_interval_sec = config.getint(SENDER_CONFIG_SECTION, 'apn_sender_interval_sec')
-    gcm_num_processes = config.getint(SENDER_CONFIG_SECTION, 'gcm_num_processes')
-    apn_num_processes = config.getint(SENDER_CONFIG_SECTION, 'apn_num_processes')
+    enabled_senders = config.get(SENDER_CONFIG_SECTION, 'enabled_senders')
     dry_run = config.getboolean(MESSENGER_CONFIG_SECTION, 'dry_run')
     request_processor_num_threads = config.getint(REQUEST_PROCESSOR_CONFIG_SECTION, 'request_processor_num_threads')
 

--- a/pushkin/database/database.py
+++ b/pushkin/database/database.py
@@ -116,7 +116,12 @@ def get_device_tokens(login_id):
     provider_tokens = set()
     for device in sorted(result): # sorting to make unit tests easier
         platform_id, device_token = device
-        provider_token = (constants.PLATFORM_BY_PROVIDER[platform_id], device_token)
+        provider_id = (constants.PLATFORM_BY_PROVIDER.get(platform_id, 0)
+                       or platform_id)
+        # NOTE: Use unique tokens per *provider* only for known providers,
+        #       and unique tokens per *platform* in other cases, since
+        #       it is hard to verify providers for custom senders
+        provider_token = (provider_id, device_token)
         if provider_token not in provider_tokens:
             devices.add(device)
             provider_tokens.add(provider_token)

--- a/pushkin/sender/sender_manager.py
+++ b/pushkin/sender/sender_manager.py
@@ -8,32 +8,96 @@ The above copyright notice and this permission notice shall be included in all c
 
 THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 '''
+import json
+import sys
+
 from pushkin.sender.nordifier import constants
-from .senders import ApnNotificationSender
-from .senders import GcmNotificationSender
-from .senders import NotificationPostProcessor
+from pushkin.sender import senders
 from pushkin import context
+from pushkin import config
 
 
 class NotificationSenderManager():
+
     def __init__(self):
-        self.apn_sender_processor = ApnNotificationSender()
-        self.gcm_sender_processor = GcmNotificationSender()
-        self.notification_post_processor = NotificationPostProcessor()
+        self.sender_by_name = {}
+        self.sender_name_by_platform = {}
+
+        values = [v.strip() for v in config.enabled_senders.split('\n')]
+        values = filter(bool, values)
+
+        if not values:
+            sys.exit(u"Nothing to start. At least one sender class must "
+                     u"be specified in config [Sender]enabled_senders")
+
+        for value in values:
+            cfg = value.split('{', 1)
+            sender_name = cfg[0].strip()
+            if not sender_name:
+                sys.exit(u"Error: bad sender configuration: {}".format(cfg))
+            try:
+                kwargs = json.loads('{' + cfg[1])
+            except IndexError:
+                kwargs = {}
+            except ValueError:
+                sys.exit(u"Error: failed to parse JSON kwargs "
+                         u"from sender configuration: {}".format(s))
+            try:
+                module, cls_name = sender_name.rsplit('.', 1)
+                sender_cls = getattr(__import__(module, fromlist=[cls_name]),
+                                     cls_name)
+                if not issubclass(sender_cls, senders.NotificationSender):
+                    raise AttributeError(
+                        u"{} must be a subclass of senders.NotificationSender"
+                        u"".format(sender_cls))
+            except (ImportError, AttributeError, TypeError) as e:
+                err = u"Failed to load sender '{}': {}: {}"
+                sys.exit(err.format(sender_name, type(e).__name__, e))
+
+            try:
+                platforms = sender_cls.PLATFORMS
+            except AttributeError:
+                err = u"Failed to load sender: missed property {}.PLATFORMS"
+                sys.exit(err.format(sender_name))
+
+            if not platforms:
+                err = u"Failed to load sender: empty {}.PLATFORMS"
+                sys.exit(err.format(sender_name))
+
+            sender_ins = sender_cls(**kwargs)
+
+            for platform in map(int, platforms):
+                if platform in self.sender_name_by_platform:
+                    rival_name = self.sender_name_by_platform[platform]
+                    err = (u"Failed to load sender '{}': platform '{}' "
+                           u"is already registered by another sender '{}'")
+                    sys.exit(err.format(sender_name, platform, rival_name))
+
+                self.sender_name_by_platform[platform] = sender_name
+
+            if config.main_log_level == context.logging.DEBUG:
+                dmesg = u"Registering sender {}({}) for platforms: {}"
+                args = ["{}={!r}".format(*i) for i in kwargs.items()]
+                print (dmesg.format(sender_name, ', '.join(args),
+                                    ', '.join(map(str, platforms))))
+            self.sender_by_name[sender_name] = sender_ins
+
+        self.notification_post_processor = senders.NotificationPostProcessor()
 
     def submit(self, notification):
-        if notification['platform'] in [constants.PLATFORM_ANDROID, constants.PLATFORM_ANDROID_TABLET]:
-            context.main_logger.debug(
-                "Submitting notification: {notification} to GcmNotificationProcessor".format(notification=notification))
-            self.gcm_sender_processor.submit(notification)
-        elif notification['platform'] in [constants.PLATFORM_IPHONE, constants.PLATFORM_IPAD]:
-            context.main_logger.debug(
-                "Submitting notification: {notification} to ApnNotificationProcessor".format(notification=notification))
-            self.apn_sender_processor.submit(notification)
+        platform = notification['platform']
+        if platform in self.sender_name_by_platform:
+            sender_name = self.sender_name_by_platform[platform]
+            sender_ins = self.sender_by_name[sender_name]
+
+            dmesg = u"Submitting notification {} to sender {}"
+            context.main_logger.debug(dmesg.format(notification, sender_name))
+
+            sender_ins.submit(notification)
         else:
-            context.main_logger.error("Unknown platform type: {0}".format(notification['platform']))
+            context.main_logger.error("Unknown platform: {}".format(platform))
 
     def start(self):
-        self.apn_sender_processor.start()
-        self.gcm_sender_processor.start()
+        for sender_ins in self.sender_by_name.values():
+            sender_ins.start()
         self.notification_post_processor.start()

--- a/pushkin/sender/senders.py
+++ b/pushkin/sender/senders.py
@@ -25,7 +25,11 @@ import timeit
 
 
 class NotificationSender(ProcessPool):
-    def __init__(self, num_workers):
+
+    NUM_WORKERS_DEFAULT = 50
+
+    def __init__(self, **kwargs):
+        num_workers = kwargs.get('workers', self.NUM_WORKERS_DEFAULT)
         ProcessPool.__init__(self, self.__class__.__name__, num_workers, config.sender_queue_limit)
 
     def limit_exceeded(self, notification):
@@ -107,8 +111,9 @@ class NotificationStatistics:
 
 
 class ApnNotificationSender(NotificationSender):
-    def __init__(self):
-        NotificationSender.__init__(self, config.apn_num_processes)
+
+    PLATFORMS = (constants.PLATFORM_IPHONE,
+                 constants.PLATFORM_IPAD)
 
     def process(self):
         sender = APNS2PushSender(config.config, context.main_logger)
@@ -129,8 +134,9 @@ class ApnNotificationSender(NotificationSender):
 
 
 class GcmNotificationSender(NotificationSender):
-    def __init__(self):
-        NotificationSender.__init__(self, config.gcm_num_processes)
+
+    PLATFORMS = (constants.PLATFORM_ANDROID,
+                 constants.PLATFORM_ANDROID_TABLET)
 
     def process(self):
         sender = GCMPushSender(config.config, context.main_logger)

--- a/pushkin/tests/test_config.ini
+++ b/pushkin/tests/test_config.ini
@@ -21,10 +21,9 @@ request_processor_num_threads = 10
 
 [Sender]
 sender_queue_limit = 50000
-# interval for batching apn messages
-apn_sender_interval_sec = 3
-apn_num_processes = 10
-gcm_num_processes = 30
+enabled_senders =
+  pushkin.sender.senders.ApnNotificationSender {"workers": 10}
+  pushkin.sender.senders.GcmNotificationSender {"workers": 30}
 
 [Log]
 main_logger_name = pushkin

--- a/pushkin/tests/test_sender_manager.py
+++ b/pushkin/tests/test_sender_manager.py
@@ -1,0 +1,67 @@
+import mock
+import pytest
+
+from pushkin.sender.nordifier import constants
+from pushkin.sender import sender_manager
+
+
+APN = 'pushkin.sender.senders.ApnNotificationSender'
+GCM = 'pushkin.sender.senders.GcmNotificationSender'
+
+
+@mock.patch('pushkin.sender.sender_manager.config')
+def test_sender_manager_init_no_senders_given(mock_config):
+    mock_config.enabled_senders.split.return_value=[]
+    with pytest.raises(SystemExit) as ex:
+        sender_manager.NotificationSenderManager()
+    assert ("Nothing to start. At least one sender class "
+            "must be specified in config") in str(ex)
+
+@mock.patch(APN)
+@mock.patch(GCM)
+def test_sender_manager_init_bad_subclass(mock_gcm, mock_apn):
+    with pytest.raises(SystemExit) as ex:
+        sender_manager.NotificationSenderManager()
+    assert ("Failed to load sender") in str(ex)
+    assert ("TypeError") in str(ex)  # issubclass(<Mock()>... => TypeError
+
+@mock.patch('pushkin.sender.sender_manager.issubclass',
+            create=True, return_value=True)
+@mock.patch(APN, PLATFORMS=(2, 5))
+@mock.patch(GCM, PLATFORMS=(1, 6))
+def test_sender_manager_init(mock_gcm, mock_apn, mock_issub):
+    mngr = sender_manager.NotificationSenderManager()
+    senders = {APN: mock_apn.return_value, GCM: mock_gcm.return_value}
+    sender_names = {1: GCM, 6: GCM, 2: APN, 5: APN}
+    assert mngr.sender_by_name == senders
+    assert mngr.sender_name_by_platform == sender_names
+    mock_gcm.assert_called_once_with(workers=30)
+    mock_apn.assert_called_once_with(workers=10)
+
+@mock.patch('pushkin.sender.sender_manager.issubclass',
+            create=True, return_value=True)
+@mock.patch(APN, PLATFORMS=(2, 5))
+@mock.patch(GCM, PLATFORMS=(1, 6))
+def test_sender_manager_start(mock_gcm, mock_apn, mock_issub):
+    mngr = sender_manager.NotificationSenderManager()
+    mngr.notification_post_processor = mock.Mock()
+    assert not mngr.sender_by_name[APN].start.called
+    assert not mngr.sender_by_name[GCM].start.called
+    mngr.start()
+    mngr.sender_by_name[APN].start.assert_called_once_with()
+    mngr.sender_by_name[GCM].start.assert_called_once_with()
+    mngr.notification_post_processor.start.assert_called_once_with()
+
+@mock.patch('pushkin.sender.sender_manager.context')
+@mock.patch('pushkin.sender.sender_manager.issubclass',
+            create=True, return_value=True)
+@mock.patch(APN, PLATFORMS=(2, 5))
+@mock.patch(GCM, PLATFORMS=(1, 6))
+def test_sender_manager_submit(mock_gcm, mock_apn, mock_issub, mock_context):
+    mngr = sender_manager.NotificationSenderManager()
+    apn_notification = {'platform': 2, 'login_id': 123, 'message_id': 42}
+    gcm_notification = {'platform': 6, 'login_id': 321, 'message_id': 24}
+    mngr.submit(apn_notification)
+    mngr.submit(gcm_notification)
+    mngr.sender_by_name[APN].submit.assert_called_once_with(apn_notification)
+    mngr.sender_by_name[GCM].submit.assert_called_once_with(gcm_notification)


### PR DESCRIPTION
Now each sender is being loaded as plugin.
This allows to explicitly load built-in senders (GCM and APN),
as well as any number of own senders implementation (and therefore
send arbitrary notifications like emails and chat messages).

Senders are specified by config option *enabled_senders*.
Each sender is represented with an importable path to sender class
and optional kwargs (in JSON) following after a whitespace.
Sender class must be a subclass of senders.NotificationSender.

Example:

```
enabled_senders =
  pushkin.sender.senders.ApnNotificationSender
  pushkin.sender.senders.GcmNotificationSender {"workers": 100}
  some.module.MySmtpSender {"workers": 10, "extra_argument": 42}
  some.module.MyChatSender
```